### PR TITLE
Dependency overwrites itself

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -16,9 +16,9 @@ function (createConnection) {
     if(onConnect)
       emitter.on('connect', onConnect)
 
-    backoff = (backoff[opts.type] || backoff.fibonacci) (opts)
+    var backoffMethod = (backoff[opts.type] || backoff.fibonacci) (opts)
 
-    backoff.on('backoff', function (n, d) {
+    backoffMethod.on('backoff', function (n, d) {
       emitter.emit('backoff', n, d)
     })
 
@@ -40,11 +40,11 @@ function (createConnection) {
         emitter.emit('disconnect', con)
 
         if(!emitter.reconnect) return
-        backoff.backoff()
+        backoffMethod.backoff()
       }
 
       con.on('connect', function () {
-        backoff.reset()
+        backoffMethod.reset()
         emitter.connected = true
         emitter.emit('connect', con)
       }).on('error', onDisconnect)
@@ -56,8 +56,8 @@ function (createConnection) {
     emitter.listen = function () {
       this.reconnect = true
       if(emitter.connected) return
-      backoff.reset()
-      backoff.on('ready', attempt)
+      backoffMethod.reset()
+      backoffMethod.on('ready', attempt)
       args = [].slice.call(arguments)
       attempt(0, 0)
       return emitter


### PR DESCRIPTION
On line [19 of inject.js](https://github.com/dominictarr/reconnect/blob/master/inject.js#L19) the backoff module is being overwritten by one of it's own methods. When the `inject()` method is called a subsequent time, the following TypeError is received

```
/Users/jmoniz/Dropbox/workspace/role-call/node_modules/reconnect/inject.js:19
    backoff = (backoff[opts.type] || backoff.fibonacci) (opts)
                                                        ^
TypeError: undefined is not a function
```

All you have to do to reproduce this error is have any node process create more then one reconnect() instances, the second one will throw the TypeError

To fix this i turned the backoff variable on line 19 into a local variable and one that doesn't conflict with the one in the global namespace.
