### PR TITLE
use sockjs-stream instead of shoe

### DIFF
--- a/examples/shoe/package.json
+++ b/examples/shoe/package.json
@@ -1,11 +1,13 @@
 {
-    "name" : "shoe-invert-example",
-    "version" : "0.0.0",
-    "dependencies" : {
-        "browserify" : "~1.13.0",
-        "ecstatic" : "~0.1.6",
-        "domready" : "~0.2.11",
-        "event-stream" : "~2.0.4"
-    },
-    "private" : true
+  "name": "shoe-invert-example",
+  "version": "0.0.0",
+  "dependencies": {
+    "browserify": "~1.16.4",
+    "ecstatic": "~0.1.6",
+    "domready": "~0.2.11",
+    "event-stream": "~2.0.4"
+  },
+  "private": true,
+  "devDependencies": {
+  }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "backoff": "~1.0.0",
-    "shoe": "0.0.4"
+    "sockjs-stream": "~0.1.2"
   },
   "devDependencies": {
     "tap": "0.3.0",

--- a/shoe.js
+++ b/shoe.js
@@ -1,7 +1,7 @@
 
-var shoe = require('shoe')
+var shoe = require('sockjs-stream')
 
-module.exports = require('./inject')(function (){ 
+module.exports = require('./inject')(function (){
   var args = [].slice.call(arguments)
   return shoe.apply(null, args)
 })


### PR DESCRIPTION
Fixes #4

sockjs-stream is a drop in replacement for shoe except when you `require("reconnect/shoe")` on the server it will work an open a ws client connection to a sockJS server
