### PR TITLE
connect flag for options

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ var opts = {
 }
 ```
 
-`opts` is optional. If `opts.intermediate` is `true` then we will treat the
+`opts` is optional. If `opts.immediate` is `true` then we will treat the
 stream as if it does not emit a `"connect"` event and fall back to listening
 to the first piece of data. This is useful for non connection streams like
 database cursors or tailing files.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ var opts = {
 }
 ```
 
-`opts` is optional.
+`opts` is optional. If `opts.connect` is `false` then we will treat the
+stream as if it does not emit a `"connect"` event and fall back to listening
+to the first piece of data.
 
 passing `onConnect` to reconnect is short hand for `reconnect(opts).on('connect', onConnect)`
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ var opts = {
 }
 ```
 
-`opts` is optional. If `opts.connect` is `false` then we will treat the
+`opts` is optional. If `opts.intermediate` is `true` then we will treat the
 stream as if it does not emit a `"connect"` event and fall back to listening
-to the first piece of data.
+to the first piece of data. This is useful for non connection streams like
+database cursors or tailing files.
 
 passing `onConnect` to reconnect is short hand for `reconnect(opts).on('connect', onConnect)`
 

--- a/inject.js
+++ b/inject.js
@@ -54,7 +54,7 @@ function (createConnection) {
         .on('close', onDisconnect)
         .on('end'  , onDisconnect)
 
-      if(opts.connect === false || con.constructor.name == 'Request') {
+      if(opts.intermediate || con.constructor.name == 'Request') {
         emitter.connected = true
         emitter.emit('connect', con)
         con.once('data', function () {

--- a/inject.js
+++ b/inject.js
@@ -54,7 +54,7 @@ function (createConnection) {
         .on('close', onDisconnect)
         .on('end'  , onDisconnect)
 
-      if(opts.intermediate || con.constructor.name == 'Request') {
+      if(opts.immediate || con.constructor.name == 'Request') {
         emitter.connected = true
         emitter.emit('connect', con)
         con.once('data', function () {

--- a/inject.js
+++ b/inject.js
@@ -30,7 +30,7 @@ function (createConnection) {
       emitter.emit('reconnect', n, delay)
       var con = createConnection.apply(null, args)
       emitter._connection = con
-      
+
       function onDisconnect (err) {
         emitter.connected = false
         con.removeListener('error', onDisconnect)
@@ -54,7 +54,7 @@ function (createConnection) {
         .on('close', onDisconnect)
         .on('end'  , onDisconnect)
 
-      if(con.constructor.name == 'Request') {
+      if(opts.connect === false || con.constructor.name == 'Request') {
         emitter.connected = true
         emitter.emit('connect', con)
         con.once('data', function () {
@@ -88,7 +88,7 @@ function (createConnection) {
     emitter.disconnect = function () {
       this.reconnect = false
       if(!emitter.connected) return emitter
-      
+
       else if(emitter._connection)
         emitter._connection.end()
 


### PR DESCRIPTION
if `opts.connect` is set to `false` then we treat this connection as if it will never emit a `"connect"` event and use the same fallback we use for HTTP.
