### PR TITLE
update shoe example to use sockjs-stream

### DIFF
--- a/examples/shoe/node-client.js
+++ b/examples/shoe/node-client.js
@@ -1,16 +1,11 @@
-var reconnect = require('../../shoe');
+var reconnect = require('../../inject')(require('sockjs-stream'))
 var es = require('event-stream');
-
-//****************************************
-//* copy pasted from ./client.js         *
-//* but without anything DOM related!    *
-//****************************************
 
 var r = reconnect(function (stream) {
   var s = es.mapSync(function (msg) {
-    console.log(msg)         
     return String(Number(msg)^1);
   });
   s.pipe(stream).pipe(s);
+  stream.pipe(process.stdout)
 
-}).connect('http://localhost:3000/invert/foo')
+}).connect('ws://localhost:3000/invert/foo')

--- a/examples/shoe/package.json
+++ b/examples/shoe/package.json
@@ -6,7 +6,8 @@
     "domready": "~0.2.11",
     "event-stream": "~2.0.4",
     "observable": "~1.4.0",
-    "browserify": "~3.24.8"
+    "browserify": "~3.24.8",
+    "sockjs-stream": "~0.1.3"
   },
   "private": true,
   "devDependencies": {},


### PR DESCRIPTION
Fixing a broken example. This works as of `data-stream@0.2.0`.
