### PR TITLE
Update sockjs-stream to latest.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "optionalDependencies": {
     "shoe": ">=0.0.7 <1",
-    "sockjs-stream": ">=0.1.2 <1"
+    "sockjs-stream": ">=1 <2"
   },
   "devDependencies": {
     "tap": "~0.4.2",


### PR DESCRIPTION
Fixes a bug (https://github.com/Raynos/sockjs-stream/issues/2) where messages were not being received that was resolved in data-channel 0.2.1 and sockjs-stream 1.0.2.
